### PR TITLE
[Tamna] 카카오로그인 후 응답 정보에 프로필 이미지 추가

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -49,7 +49,8 @@ class UserTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(),{
             "message"     : "SUCCESS_LOGIN",
-            "access_token": access_token
+            "access_token": access_token,
+            "user_image"  : "test.jpg"
         })
 
     @patch("users.views.requests")
@@ -77,7 +78,8 @@ class UserTest(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json(),{
             "message"     : "CREATED_NEW_USER",
-            "access_token": access_token
+            "access_token": access_token,
+            "user_image"  : None
         })
 
     @patch("users.views.requests")

--- a/users/views.py
+++ b/users/views.py
@@ -43,10 +43,12 @@ class KakaoSignInView(View):
             status_code  = 201 if is_created else 200
             message      = "CREATED_NEW_USER" if is_created else "SUCCESS_LOGIN"
             access_token = jwt.encode({"user_id": user.id}, settings.SECRET_KEY, settings.ALGORITHM)
-            
+            user_image   = user.profile_img if not is_created else None
+
             messages = {
                 "message"     : message,
-                "access_token": access_token
+                "access_token": access_token,
+                "user_image"  : user_image
             }
 
             return JsonResponse(messages, status=status_code)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 수정 사항

1. 카카오 로그인 성공을 했을 때 유저의 프로필 사진이 DB 정보에 있으면 보내주고 없으면 None 값 반환 추가

2. 테스트 코드 수정 및 테스트 완료
<img width="351" alt="image" src="https://user-images.githubusercontent.com/93123657/178921944-5f323980-4fa9-4a08-b7b7-903033a8540f.png">

<br>

## :: 질문사항

1. 제가 setUp함수에서 매번 데이터를 만들어서 테스트 코드 실행 속도가 느린 것인가요?

2. 현재 aws에 배포를 한 상태인데, main 브랜치가 merge가 되어 새로운 버전으로 바뀌면 배포된 API도 자동으로 수정되는 것인가요?